### PR TITLE
iter_prefix maximally generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
-- wildcard_iter that supports \* (any) and ? (one) wildcards in search pattern
+- `wildcard_iter` that supports \* (any) and ? (one) wildcards in search pattern
+
+### Changed
+
+- `iter_prefix` and `iter_prefix_mut` is more permissive in the generic key types it accepts
 
 ## [1.1.1]
 
-## Fixed
+### Fixed
 
 - fixed >255 len nodes where there is a partial match
 
-## Added
+### Added
 
 - `lcp_by4`/`lcp_by8`
 
-## Changed
+### Changed
 
 - `fmt::Debug` output look
 
 ## [1.1.0]
 
-## Added
+### Added
 
 - trait impl BorrowedBytes for static sized arrays
 - `entry` API for tree/map
 
-## Changed
+### Changed
 
 - allow for key lens greater than 255
 
-## Removed
+### Removed
 
 - unused trait methods in BorrowedBytes

--- a/src/map.rs
+++ b/src/map.rs
@@ -562,7 +562,7 @@ impl<K: Bytes, V> GenericRadixMap<K, V> {
     /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3)],
     ///            map.iter_prefix(b"ba").collect::<Vec<_>>());
     /// ```
-    pub fn iter_prefix<'a, Q>(&'a self, prefix: &Q) -> impl 'a + Iterator<Item = (K, &'a V)>
+    pub fn iter_prefix<'a, Q>(&'a self, prefix: &Q) -> impl Iterator<Item = (K, &'a V)>
     where
         Q: ?Sized + AsRef<K::Borrowed>,
     {
@@ -586,10 +586,7 @@ impl<K: Bytes, V> GenericRadixMap<K, V> {
     /// assert_eq!(vec![(Vec::from("bar"), &mut 2), ("baz".into(), &mut 3)],
     ///            map.iter_prefix_mut(b"ba").collect::<Vec<_>>());
     /// ```
-    pub fn iter_prefix_mut<'a, Q>(
-        &'a mut self,
-        prefix: &Q,
-    ) -> impl 'a + Iterator<Item = (K, &'a mut V)>
+    pub fn iter_prefix_mut<'a, Q>(&'a mut self, prefix: &Q) -> impl Iterator<Item = (K, &'a mut V)>
     where
         Q: ?Sized + AsRef<K::Borrowed>,
     {

--- a/src/map.rs
+++ b/src/map.rs
@@ -562,13 +562,16 @@ impl<K: Bytes, V> GenericRadixMap<K, V> {
     /// assert_eq!(vec![(Vec::from("bar"), &2), ("baz".into(), &3)],
     ///            map.iter_prefix(b"ba").collect::<Vec<_>>());
     /// ```
-    pub fn iter_prefix<'a>(&'a self, prefix: &K::Borrowed) -> impl Iterator<Item = (K, &'a V)> {
+    pub fn iter_prefix<'a, Q>(&'a self, prefix: &Q) -> impl 'a + Iterator<Item = (K, &'a V)>
+    where
+        Q: ?Sized + AsRef<K::Borrowed>,
+    {
+        let prefix = prefix.as_ref();
         self.tree
             .iter_prefix(prefix)
+            .map(|(prefix_len, nodes)| (Vec::from(&prefix.as_bytes()[..prefix_len]), nodes))
             .into_iter()
-            .flat_map(move |(prefix_len, nodes)| {
-                Iter::<K, V>::new(nodes, Vec::from(&prefix.as_bytes()[..prefix_len]))
-            })
+            .flat_map(|(prefix_bytes, nodes)| Iter::<K, V>::new(nodes, prefix_bytes))
     }
 
     /// Gets a mutable iterator over the entries having the given prefix of this map, sorted by key.
@@ -583,16 +586,21 @@ impl<K: Bytes, V> GenericRadixMap<K, V> {
     /// assert_eq!(vec![(Vec::from("bar"), &mut 2), ("baz".into(), &mut 3)],
     ///            map.iter_prefix_mut(b"ba").collect::<Vec<_>>());
     /// ```
-    pub fn iter_prefix_mut<'a>(
+    pub fn iter_prefix_mut<'a, Q>(
         &'a mut self,
-        prefix: &K::Borrowed,
-    ) -> impl Iterator<Item = (K, &'a mut V)> {
-        self.tree
+        prefix: &Q,
+    ) -> impl 'a + Iterator<Item = (K, &'a mut V)>
+    where
+        Q: ?Sized + AsRef<K::Borrowed>,
+    {
+        let prefix = prefix.as_ref();
+        let result = self
+            .tree
             .iter_prefix_mut(prefix)
+            .map(|(prefix_len, nodes)| (Vec::from(&prefix.as_bytes()[..prefix_len]), nodes));
+        result
             .into_iter()
-            .flat_map(move |(prefix_len, nodes)| {
-                IterMut::<K, V>::new(nodes, Vec::from(&prefix.as_bytes()[..prefix_len]))
-            })
+            .flat_map(|(prefix_bytes, nodes)| IterMut::<K, V>::new(nodes, prefix_bytes))
     }
 }
 
@@ -1113,72 +1121,72 @@ mod tests {
         assert_eq!(items, vec![])
     }
 
-    // #[test]
-    // fn iter_prefix_keys() {
-    //     let mut map = RadixMap::new();
-    //     map.insert("foobar", 1);
-    //     map.insert("foobaz", 2);
-    //     map.insert("fooqox", 3);
+    #[test]
+    fn iter_prefix_keys() {
+        let mut map = RadixMap::new();
+        map.insert("foobar", 1);
+        map.insert("foobaz", 2);
+        map.insert("fooqox", 3);
 
-    //     let mut items: Vec<_> = map.iter_prefix("foo").collect();
-    //     items.sort_by(|a, b| a.0.cmp(&b.0));
-    //     assert_eq!(
-    //         items,
-    //         vec![
-    //             (b"foobar".to_vec(), &1),
-    //             (b"foobaz".to_vec(), &2),
-    //             (b"fooqox".to_vec(), &3),
-    //         ]
-    //     );
+        let mut items: Vec<_> = map.iter_prefix("foo").collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            items,
+            vec![
+                (b"foobar".to_vec(), &1),
+                (b"foobaz".to_vec(), &2),
+                (b"fooqox".to_vec(), &3),
+            ]
+        );
 
-    //     // prefix that consumes part of a shared node label
-    //     let mut items: Vec<_> = map.iter_prefix("foob").collect();
-    //     items.sort_by(|a, b| a.0.cmp(&b.0));
-    //     assert_eq!(
-    //         items,
-    //         vec![(b"foobar".to_vec(), &1), (b"foobaz".to_vec(), &2),]
-    //     );
-    // }
+        // prefix that consumes part of a shared node label
+        let mut items: Vec<_> = map.iter_prefix("foob").collect();
+        items.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            items,
+            vec![(b"foobar".to_vec(), &1), (b"foobaz".to_vec(), &2),]
+        );
+    }
 
-    // #[test]
-    // fn iter_prefix_lifetime() {
-    //     // 'b (prefix) is shorter than 'a (map). items hold &'a V so they're
-    //     // valid after prefix drops since they borrow from map, not prefix.
-    //     let mut map = RadixMap::new();
-    //     map.insert("foo/bar", 1);
-    //     map.insert("foo/baz", 2);
-    //     map.insert("other", 3);
+    #[test]
+    fn iter_prefix_lifetime() {
+        // 'b (prefix) is shorter than 'a (map). items hold &'a V so they're
+        // valid after prefix drops since they borrow from map, not prefix.
+        let mut map = RadixMap::new();
+        map.insert("foo/bar", 1);
+        map.insert("foo/baz", 2);
+        map.insert("other", 3);
 
-    //     // prefix dropped at end of block, items used outside
-    //     let items: Vec<_> = {
-    //         let prefix = b"foo/".to_vec();
-    //         map.iter_prefix(&prefix).collect()
-    //     };
-    //     assert_eq!(items.len(), 2);
-    //     assert!(items.iter().any(|(k, _)| k == b"foo/bar"));
-    //     assert!(items.iter().any(|(k, _)| k == b"foo/baz"));
-    //     assert_eq!(*items[0].1 + *items[1].1, 3);
+        // prefix dropped at end of block, items used outside
+        let items: Vec<_> = {
+            let prefix = b"foo/".to_vec();
+            map.iter_prefix(&prefix).collect()
+        };
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().any(|(k, _)| k == b"foo/bar"));
+        assert!(items.iter().any(|(k, _)| k == b"foo/baz"));
+        assert_eq!(*items[0].1 + *items[1].1, 3);
 
-    //     // works with String too
-    //     let items: Vec<_> = {
-    //         let prefix = "foo/".to_owned();
-    //         map.iter_prefix(&prefix).collect()
-    //     };
-    //     assert_eq!(items.len(), 2);
+        // works with String too
+        let items: Vec<_> = {
+            let prefix = "foo/".to_owned();
+            map.iter_prefix(&prefix).collect()
+        };
+        assert_eq!(items.len(), 2);
 
-    //     // same for mut, &mut V refs outlive prefix
-    //     let items: Vec<_> = {
-    //         let prefix = b"foo/".to_vec();
-    //         map.iter_prefix_mut(&prefix).collect()
-    //     };
-    //     assert_eq!(items.len(), 2);
-    //     for (_, v) in items {
-    //         *v += 10;
-    //     }
-    //     assert_eq!(map.get("foo/bar"), Some(&11));
-    //     assert_eq!(map.get("foo/baz"), Some(&12));
-    //     assert_eq!(map.get("other"), Some(&3));
-    // }
+        // same for mut, &mut V refs outlive prefix
+        let items: Vec<_> = {
+            let prefix = b"foo/".to_vec();
+            map.iter_prefix_mut(&prefix).collect()
+        };
+        assert_eq!(items.len(), 2);
+        for (_, v) in items {
+            *v += 10;
+        }
+        assert_eq!(map.get("foo/bar"), Some(&11));
+        assert_eq!(map.get("foo/baz"), Some(&12));
+        assert_eq!(map.get("other"), Some(&3));
+    }
 
     #[test]
     fn issue42_common_prefix_values() {

--- a/src/map.rs
+++ b/src/map.rs
@@ -594,11 +594,9 @@ impl<K: Bytes, V> GenericRadixMap<K, V> {
         Q: ?Sized + AsRef<K::Borrowed>,
     {
         let prefix = prefix.as_ref();
-        let result = self
-            .tree
+        self.tree
             .iter_prefix_mut(prefix)
-            .map(|(prefix_len, nodes)| (Vec::from(&prefix.as_bytes()[..prefix_len]), nodes));
-        result
+            .map(|(prefix_len, nodes)| (Vec::from(&prefix.as_bytes()[..prefix_len]), nodes))
             .into_iter()
             .flat_map(|(prefix_bytes, nodes)| IterMut::<K, V>::new(nodes, prefix_bytes))
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -292,9 +292,9 @@ impl<T: Bytes> GenericRadixSet<T> {
     ///
     /// assert_eq!(set.iter_prefix(b"ba").collect::<Vec<_>>(), [Vec::from("bar"), "baz".into()]);
     /// ```
-    pub fn iter_prefix<'a, 'b>(&'a self, prefix: &'b T::Borrowed) -> impl 'a + Iterator<Item = T>
+    pub fn iter_prefix<U>(&self, prefix: &U) -> impl Iterator<Item = T>
     where
-        'b: 'a,
+        U: ?Sized + AsRef<T::Borrowed>,
     {
         self.map.iter_prefix(prefix).map(|(k, _)| k)
     }


### PR DESCRIPTION
While editing wildcard_iter to take generic key arguments it occurred to me that iter_prefix is similarly limited. If you shuffle around the order of operations you can take ?Sized arguments. Uncomments tests that previously would have failed.

The changes are more permissive than before so I don't think it introduces any compatibility issues with the original patricia_tree public API