### PR TITLE
Preserve "empty label root" invariant in split_by_prefix

### DIFF
--- a/src/node_common.rs
+++ b/src/node_common.rs
@@ -364,6 +364,7 @@ impl<V> Node<V> {
         let key = key.as_bytes();
         let mut suffix = key;
         let mut parent: *mut Node<V> = &raw mut *cur;
+        let root: *const Node<V> = parent;
         // descend as we would for `get_prefix_node` but keep the parent ptr to lag behind `cur`
         loop {
             let Some(key_suffix) = crate::strip_prefix(suffix, cur.label()) else {
@@ -391,6 +392,13 @@ impl<V> Node<V> {
         // - `parent` points to a valid Node<V> that was obtained from `&raw mut *cur` earlier
         // - The pointer remains valid because we haven't moved or deallocated the node
         // - We have exclusive access through the original `&mut self` parameter
+        //
+        // `parent` lags one node behind `cur`, so it still points at the node this method
+        // was called on (the tree root) when the detached child hangs directly off of it.
+        // The root must never be merged with a leftover single child below: keys are
+        // resolved starting at the root's label, so absorbing the child's label into the
+        // root would prepend it to every remaining key
+        let parent_is_root = core::ptr::eq(parent, root);
         let parent = unsafe { &mut *parent };
 
         // SAFETY: using `cur` after mutating parent can cause UB
@@ -425,7 +433,9 @@ impl<V> Node<V> {
             // - The child at child_index is the one we've been working with
             unsafe {
                 let detached = parent.remove_child(child_index);
-                parent.try_merge_child();
+                if !parent_is_root {
+                    parent.try_merge_child();
+                }
                 Some(detached)
             }
         } else if suffix.is_empty() {
@@ -434,7 +444,9 @@ impl<V> Node<V> {
             // - `remove_child(child_index)` is safe because child_index is a valid index
             let mut detached = unsafe { parent.remove_child(child_index) };
             detached.replace_label(key);
-            parent.try_merge_child();
+            if !parent_is_root {
+                parent.try_merge_child();
+            }
             Some(detached)
         } else {
             // if suffix > child.label_len then we didn't descend far enough?
@@ -2470,6 +2482,36 @@ mod tests {
         let mut root = create_bigger_test_tree();
         let other = root.split_by_prefix("xyx");
         assert_eq!(other, None);
+    }
+
+    #[test]
+    fn test_split_by_prefix_does_not_collapse_root() {
+        // when the split leaves the root valueless with a single child, the
+        // root must not be merged into that child: keys are resolved starting
+        // at the root's label, so absorbing the child's label would prepend it
+        // to every remaining key
+        let mut root = Node::root();
+        root.insert("foo", 1);
+        root.insert("bar", 2);
+
+        let detached = root.split_by_prefix("foo").unwrap();
+        assert_eq!(detached.label(), b"foo");
+        assert_eq!(detached.value(), Some(&1));
+
+        assert_eq!(root.label(), b"");
+        assert_eq!(root.get("bar"), Some(&2));
+        assert_eq!(root.remove("bar"), Some(2));
+
+        // same, but the detached node keeps a subtree
+        let mut root = Node::root();
+        root.insert("foo", 1);
+        root.insert("foobar", 2);
+        root.insert("qux", 3);
+
+        let detached = root.split_by_prefix("foo").unwrap();
+        assert_eq!(detached.label(), b"foo");
+        assert_eq!(root.label(), b"");
+        assert_eq!(root.remove("qux"), Some(3));
     }
 
     #[test]

--- a/src/set.rs
+++ b/src/set.rs
@@ -469,6 +469,43 @@ mod tests {
     }
 
     #[test]
+    fn split_by_prefix_keeps_root_label_empty() {
+        // splitting off "foo" leaves the root valueless with the single child
+        // "bar"; the root must not be merged into it, otherwise its label
+        // becomes "bar" and every operation that anchors keys at the root
+        // stops matching
+        let mut set: RadixSet = vec!["foo", "bar"].into_iter().collect();
+        let splitted_set = set.split_by_prefix("foo");
+        assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"foo"]);
+
+        assert!(set.contains("bar"));
+        assert!(
+            set.remove("bar"),
+            "remove must see the same keys as contains"
+        );
+        assert!(set.is_empty());
+
+        // a second split must also still find the remaining key
+        let mut set: RadixSet = vec!["foo", "bar"].into_iter().collect();
+        set.split_by_prefix("foo");
+        let splitted_set = set.split_by_prefix("ba");
+        assert_eq!(splitted_set.iter().collect::<Vec<_>>(), [b"bar"]);
+        assert!(set.is_empty());
+
+        // with the root collapsed to "bar", removing the non-member key "bar"
+        // used to match the child spelling "barbar" and silently delete it
+        let mut set: RadixSet = vec!["foo", "barbar", "barqux"].into_iter().collect();
+        set.split_by_prefix("foo");
+        assert!(!set.contains("bar"));
+        assert!(
+            !set.remove("bar"),
+            "must not remove a key that is not in the set"
+        );
+        assert!(set.contains("barbar"));
+        assert!(set.contains("barqux"));
+    }
+
+    #[test]
     fn iter_prefix_works() {
         fn assert_iter_prefix(set: &RadixSet, prefix: &str) {
             let actual = set.iter_prefix(prefix.as_bytes()).collect::<Vec<_>>();


### PR DESCRIPTION
Radix containers rely on the invariant that the root has an empty label. split_by_prefix can leave the root non-empty, which leads to container corruption.

This change skips root merge at the node-level interface, which wider than maintaining the “empty-label root” invariant at the container level. I can narrow the change if you prefer.